### PR TITLE
Fix options to metadata.json validation

### DIFF
--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -14,8 +14,11 @@ PuppetLint::RakeTask.new :lint do |config|
 end
 
 PuppetSyntax.exclude_paths = ["spec/fixtures/**/*.pp", "vendor/**/*"]
+<% if @configs['metadata-json-lint_options'] and !@configs['metadata-json-lint_options'].empty? -%>
 
 desc "Lint metadata.json file"
+Rake::Task[:metadata].clear
 task :metadata do
   sh "metadata-json-lint metadata.json<%= @configs['metadata-json-lint_options'].map { |r| ' --' + r }.join() if @configs['metadata-json-lint_options'] %>"
 end
+<% end -%>


### PR DESCRIPTION
New version of puppetlabs_spec_helper already defines the metadata rake
task without the possibility to pass options.
This fix clear the task defined in puppetlabs_spec_helper and creates a
new one with the options.