### PR TITLE
github-changelog-generator fails to build, in latest version, make sure it is not used

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -45,6 +45,7 @@ Gemfile:
       - gem: rspec-puppet-facts
       - gem: ruby-augeas
       - gem: github_changelog_generator
+        version: '< 1.11.0'
         condition: 'RUBY_VERSION !~ /^1\.8/'
       - gem: puppet-blacksmith
         condition: 'RUBY_VERSION !~ /^1\./'


### PR DESCRIPTION
Version 1.11.0 of github-changelog-generator fails to build in our unit
test environment. Blacklist this version and all next releases until the
fix is available. At which point we will need to remove the constraint.