### PR TITLE
Use the "new" Task name for metadata checking of puppet modules

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -5,7 +5,7 @@
     - bundle exec rake validate
     - bundle exec rake lint
     - bundle exec rake spec SPEC_OPTS='--format documentation'
-    - bundle exec rake metadata
+    - bundle exec rake metadata_lint
   forge_login: "camptocamp"
   includes:
   - rvm: 1.8.7


### PR DESCRIPTION
This Task was added a while back and the one we used was deprecated.
The Task we used was removed recently making unit tests fail.
Fix the issue by using the newer Task name.