### PR TITLE
add default config for stale-bot

### DIFF
--- a/moduleroot/.github/stale.yml
+++ b/moduleroot/.github/stale.yml
@@ -1,0 +1,20 @@
+# Config for stale-bot
+# See https://probot.github.io/apps/stale/
+
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 366
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 31
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
with quite large delays:
 * 1 year before marking an issue/PR stale. 
 * then 1 more month before closing it.